### PR TITLE
Fix inverted condition

### DIFF
--- a/src/main/java/jota/IotaAPI.java
+++ b/src/main/java/jota/IotaAPI.java
@@ -118,7 +118,7 @@ public class IotaAPI extends IotaAPICore {
             throw new InvalidSecurityLevelException();
         }
 
-        start = start != null ? 0 : start;
+        start = start == null ? 0 : start;
 
         if (start > end || end > (start + 500)) {
             throw new ArgumentException();


### PR DESCRIPTION
Found by Eclipse's static null value analyzer.

It makes no sense to set the value to 0 if it is not null. That way, null remains null (and will create a NPE in line 123), and all other values get overwritten by 0. Therefore, overwrite null by zero, fixing both warnings.