### PR TITLE
Fixed wrong handling of bundle-hash for seclevels > 3.

### DIFF
--- a/jota/src/main/java/jota/utils/IotaAPIUtils.java
+++ b/jota/src/main/java/jota/utils/IotaAPIUtils.java
@@ -94,18 +94,19 @@ public class IotaAPIUtils {
                     //  Add parts of signature for bundles with same address
                     if (bundle.getTransactions().get(i + j).getAddress().equals(thisAddress)) {
                         // Use 6562 trits starting from j*6561
-                        int[] secondFragment = Arrays.copyOfRange(key, 6561 * j, 6561 * (j + 1));
+                        int[] keyFragment = Arrays.copyOfRange(key, 6561 * j, 6561 * (j + 1));
 
                         // The current part of the bundle hash
-                        int[] secondBundleFragment = Arrays.copyOfRange(normalizedBundleHash, 27 * hashPart, 27 * (hashPart + 1));
+                        int[] bundleFragment = Arrays.copyOfRange(normalizedBundleHash, 27 * hashPart, 27 * (hashPart + 1));
 
                         //  Calculate the new signature
-                        int[] secondSignedFragment = new Signing(curl).signatureFragment(secondBundleFragment, secondFragment);
+                        int[] signedFragment = new Signing(curl).signatureFragment(bundleFragment, keyFragment);
 
                         //  Convert signature to trytes and assign it again to this bundle entry
-                        bundle.getTransactions().get(i+j).setSignatureFragments(Converter.trytes(secondSignedFragment));
+                        bundle.getTransactions().get(i+j).setSignatureFragments(Converter.trytes(signedFragment));
                     }
-                    else throw new ArgumentException("Inconsistent security-level and transactions");
+					else
+						throw new ArgumentException("Inconsistent security-level and transactions");
                 }
             }
         }

--- a/jota/src/main/java/jota/utils/IotaAPIUtils.java
+++ b/jota/src/main/java/jota/utils/IotaAPIUtils.java
@@ -82,34 +82,22 @@ public class IotaAPIUtils {
                 // Get corresponding private key of address
                 int[] key = new Signing(curl).key(Converter.trits(seed), keyIndex, keySecurity);
 
-                //  First 6561 trits for the firstFragment
-                int[] firstFragment = Arrays.copyOfRange(key, 0, 6561);
 
                 //  Get the normalized bundle hash
                 int[] normalizedBundleHash = bundle.normalizedBundle(bundleHash);
 
-                //  First bundle fragment uses 27 trytes
-                int[] firstBundleFragment = Arrays.copyOfRange(normalizedBundleHash, 0, 27);
+                // for each security level, add signature
+                for (int j = 0; j < keySecurity; j++) {
+                	
+                	int hashPart = j % 3;
 
-                //  Calculate the new signatureFragment with the first bundle fragment
-                int[] firstSignedFragment = new Signing(curl).signatureFragment(firstBundleFragment, firstFragment);
-
-                //  Convert signature to trytes and assign the new signatureFragment
-                bundle.getTransactions().get(i).setSignatureFragments(Converter.trytes(firstSignedFragment));
-
-                // if user chooses higher than 27-tryte security
-                // for each security level, add an additional signature
-                for (int j = 1; j < keySecurity; j++) {
-
-                    //  Because the signature is > 2187 trytes, we need to
-                    //  find the second transaction to add the remainder of the signature
-                    //  Same address as well as value = 0 (as we already spent the input)
-                    if (bundle.getTransactions().get(i + j).getAddress().equals(thisAddress) && bundle.getTransactions().get(i + j).getValue() == 0) {
-                        // Use the second 6562 trits
+                    //  Add parts of signature for bundles with same address
+                    if (bundle.getTransactions().get(i + j).getAddress().equals(thisAddress)) {
+                        // Use 6562 trits starting from j*6561
                         int[] secondFragment = Arrays.copyOfRange(key, 6561 * j, 6561 * (j + 1));
 
-                        // The second 27 to 54 trytes of the bundle hash
-                        int[] secondBundleFragment = Arrays.copyOfRange(normalizedBundleHash, 27 * j, 27 * (j + 1));
+                        // The current part of the bundle hash
+                        int[] secondBundleFragment = Arrays.copyOfRange(normalizedBundleHash, 27 * hashPart, 27 * (hashPart + 1));
 
                         //  Calculate the new signature
                         int[] secondSignedFragment = new Signing(curl).signatureFragment(secondBundleFragment, secondFragment);
@@ -117,6 +105,7 @@ public class IotaAPIUtils {
                         //  Convert signature to trytes and assign it again to this bundle entry
                         bundle.getTransactions().get(i+j).setSignatureFragments(Converter.trytes(secondSignedFragment));
                     }
+                    else throw new ArgumentException("Inconsistent security-level and transactions");
                 }
             }
         }


### PR DESCRIPTION
In addition to fix the handling of th bundle-hash, I moved the first signature-part into the loop. 