### PR TITLE
Fix jitpack dependency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ allprojects {
 Add this in your module `build.gradle` file:
 ```gradle
 dependencies {
-    compile 'com.github.iotaledger:iota.lib.java:0.9.10'
+    compile 'com.github.iotaledger:iota~lib~java:0.9.10'
 }
 ```
 
@@ -75,7 +75,7 @@ Add this in your module `pom.xml` file:
 ```xml
 <dependency>
     <groupId>com.github.iotaledger</groupId>
-    <artifactId>iota.lib.java</artifactId>
+    <artifactId>iota~lib~java</artifactId>
     <version>v0.9.10</version>
 </dependency>
 ```


### PR DESCRIPTION
When the name of the repository contain dots (`.`) the url of the jitpack doesn't work.
The dots need to be replaced by `~`, in other case jitpack return you an unauthorized error.
If you are using gradle, the error is:
```
* What went wrong:
Could not determine the dependencies of task ':jar'.
> Could not resolve all files for configuration ':compile'.
   > Could not resolve com.github.iotaledger.iota.lib.java:jota:0.9.10.
     Required by:
         project : > com.github.iotaledger:iota.lib.java:0.9.10
      > Could not resolve com.github.iotaledger.iota.lib.java:jota:0.9.10.
         > Could not get resource 'https://jitpack.io/com/github/iotaledger/iota/lib/java/jota/0.9.10/jota-0.9.10.pom'.
            > Could not GET 'https://jitpack.io/com/github/iotaledger/iota/lib/java/jota/0.9.10/jota-0.9.10.pom'. Received status code 401 from server: Unauthorized
```

On that issue, they explain how to fix it:
https://github.com/jitpack/jitpack.io/issues/1145