### PR TITLE
Fixed versioning in maven example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Add this in your module `pom.xml` file:
 <dependency>
     <groupId>com.github.iotaledger</groupId>
     <artifactId>iota~lib~java</artifactId>
-    <version>v0.9.10</version>
+    <version>0.9.10</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Newer versions of the lib don't prefix the version number with a 'v' letter. Using the code from the example fails to get dependency.