### PR TITLE
Add `checkConsistency` and `promoteTransaction` API endpoints

### DIFF
--- a/jota/src/main/java/jota/IotaAPICommands.java
+++ b/jota/src/main/java/jota/IotaAPICommands.java
@@ -19,7 +19,8 @@ public enum IotaAPICommands {
     ATTACH_TO_TANGLE("attachToTangle"),
     INTERRUPT_ATTACHING_TO_TANGLE("interruptAttachingToTangle"),
     BROADCAST_TRANSACTIONS("broadcastTransactions"),
-    STORE_TRANSACTIONS("storeTransactions");
+    STORE_TRANSACTIONS("storeTransactions"),
+    CHECK_CONSISTENCY("checkConsistency");
 
     private String command;
 

--- a/jota/src/main/java/jota/IotaAPICore.java
+++ b/jota/src/main/java/jota/IotaAPICore.java
@@ -293,14 +293,22 @@ public class IotaAPICore {
     }
 
     /**
-     * Tip selection which returns trunkTransaction and branchTransaction. The input value is the latest coordinator milestone, as provided through the getNodeInfo API call.
+     * Tip selection which returns trunkTransaction and branchTransaction.
      *
      * @param depth The number of bundles to go back to determine the transactions for approval.
+     * @param reference The reference transaction to start the random walk from.
      * @return The Tip selection which returns trunkTransaction and branchTransaction
      */
-    public GetTransactionsToApproveResponse getTransactionsToApprove(Integer depth) {
-        final Call<GetTransactionsToApproveResponse> res = service.getTransactionsToApprove(IotaGetTransactionsToApproveRequest.createIotaGetTransactionsToApproveRequest(depth));
+    public GetTransactionsToApproveResponse getTransactionsToApprove(Integer depth, String reference) {
+        final Call<GetTransactionsToApproveResponse> res = service.getTransactionsToApprove(IotaGetTransactionsToApproveRequest.createIotaGetTransactionsToApproveRequest(depth, reference));
         return wrapCheckedException(res).body();
+    }
+
+    /**
+     * {@link #getTransactionsToApprove(Integer, String)}
+     */
+    public GetTransactionsToApproveResponse getTransactionsToApprove(Integer depth) {
+        return getTransactionsToApprove(depth, null);
     }
 
     /**
@@ -332,6 +340,22 @@ public class IotaAPICore {
         }
         return getBalances(threshold, addressesWithoutChecksum.toArray(new String[]{}));
     }
+
+    /**
+     * Checks the consistency of the subtangle formed by the provided tails.
+     *
+     * @param tails The tails describing the subtangle.
+     * @return The The the raw transaction data (trytes) of a specific transaction.
+     */
+    public CheckConsistencyResponse checkConsistency(String... tails) throws ArgumentException {
+        if (!InputValidator.isArrayOfHashes(tails)) {
+            throw new ArgumentException(INVALID_HASHES_INPUT_ERROR);
+        }
+
+        final Call<CheckConsistencyResponse> res = service.checkConsistency(IotaCheckConsistencyRequest.create(tails));
+        return wrapCheckedException(res).body();
+    }
+
 
     /**
      * Attaches the specified transactions (trytes) to the Tangle by doing Proof of Work.

--- a/jota/src/main/java/jota/IotaAPIService.java
+++ b/jota/src/main/java/jota/IotaAPIService.java
@@ -159,4 +159,14 @@ public interface IotaAPIService {
     @Headers({CONTENT_TYPE_HEADER, USER_AGENT_HEADER})
     @POST("./")
     Call<StoreTransactionsResponse> storeTransactions(@Body IotaStoreTransactionsRequest request);
+
+    /**
+     * Checks the consistency of the subtangle descirbed by the provided tails.
+     * <p>
+     * {@code curl http://localhost:14265 -X POST -H 'X-IOTA-API-Version: 1.4.1' -H 'Content-Type: application/json'}
+     * {@code -d '{"command": "checkConsistency", "tails": ["AYHLOYXFXYNBX9L9TLS9LGKPGJCTHVPEVYNMZEEIPVBVLSIBZEJRKXYYOW9NXKTNQSVFBMGUKVYOZ9999"]}'}
+     */
+    @Headers({CONTENT_TYPE_HEADER, USER_AGENT_HEADER})
+    @POST("./")
+    Call<CheckConsistencyResponse> checkConsistency(@Body IotaCheckConsistencyRequest request);
 }

--- a/jota/src/main/java/jota/dto/request/IotaCheckConsistencyRequest.java
+++ b/jota/src/main/java/jota/dto/request/IotaCheckConsistencyRequest.java
@@ -1,0 +1,45 @@
+package jota.dto.request;
+
+import jota.IotaAPICommands;
+
+/**
+ * This class represents the core api request 'checkConsistency'.
+ **/
+public class IotaCheckConsistencyRequest extends IotaCommandRequest {
+
+    private String[] tails;
+
+    /**
+     * Initializes a new instance of the IotaCheckConsistencyRequest class.
+     */
+    private IotaCheckConsistencyRequest(final String... tails) {
+        super(IotaAPICommands.CHECK_CONSISTENCY);
+        this.tails = tails;
+    }
+
+    /**
+     * Create a new instance of the IotaGetBalancesRequest class.
+     */
+    public static IotaCheckConsistencyRequest create(final String... tails) {
+        return new IotaCheckConsistencyRequest(tails);
+    }
+
+    /**
+     * Gets the tails.
+     *
+     * @return The tails.
+     */
+    public String[] getTails() {
+        return tails;
+    }
+
+    /**
+     * Sets the tails.
+     *
+     * @param tails The tails.
+     */
+    public void setTails(String[] tails) {
+        this.tails = tails;
+    }
+}
+

--- a/jota/src/main/java/jota/dto/request/IotaGetTransactionsToApproveRequest.java
+++ b/jota/src/main/java/jota/dto/request/IotaGetTransactionsToApproveRequest.java
@@ -7,38 +7,59 @@ import jota.IotaAPICommands;
  **/
 public class IotaGetTransactionsToApproveRequest extends IotaCommandRequest {
 
-    private Integer depth;
+  private Integer depth;
+  private String reference;
 
-    /**
-     * Initializes a new instance of the IotaGetTransactionsToApproveRequest class.
-     */
-    private IotaGetTransactionsToApproveRequest(final Integer depth) {
-        super(IotaAPICommands.GET_TRANSACTIONS_TO_APPROVE);
-        this.depth = depth;
-    }
+  /**
+   * Initializes a new instance of the IotaGetTransactionsToApproveRequest class.
+   */
+  private IotaGetTransactionsToApproveRequest(final Integer depth, final String reference) {
+    super(IotaAPICommands.GET_TRANSACTIONS_TO_APPROVE);
+    this.depth = depth;
+    this.reference = reference;
+  }
 
-    /**
-     * Create a new instance of the IotaGetTransactionsToApproveRequest class.
-     */
-    public static IotaGetTransactionsToApproveRequest createIotaGetTransactionsToApproveRequest(Integer depth) {
-        return new IotaGetTransactionsToApproveRequest(depth);
-    }
+  /**
+   * Create a new instance of the IotaGetTransactionsToApproveRequest class.
+   */
+  public static IotaGetTransactionsToApproveRequest createIotaGetTransactionsToApproveRequest(Integer depth, String reference) {
+    return new IotaGetTransactionsToApproveRequest(depth, reference);
+  }
 
-    /**
-     * Gets the depth.
-     *
-     * @return The depth.
-     */
-    public Integer getDepth() {
-        return depth;
-    }
+  /**
+   * Gets the depth.
+   *
+   * @return The depth.
+   */
+  public Integer getDepth() {
+    return depth;
+  }
 
-    /**
-     * Sets the depth.
-     *
-     * @param depth The depth.
-     */
-    public void setDepth(Integer depth) {
-        this.depth = depth;
-    }
+  /**
+   * /**
+   * Sets the depth.
+   *
+   * @param depth The depth.
+   */
+  public void setDepth(Integer depth) {
+    this.depth = depth;
+  }
+
+  /**
+   * Gets the reference to use
+   *
+   * @return The reference point.
+   */
+  public String getReference() {
+    return reference;
+  }
+
+  /**
+   * Sets the reference.
+   *
+   * @param reference The reference
+   */
+  public void setReference(String reference) {
+    this.reference = reference;
+  }
 }

--- a/jota/src/main/java/jota/dto/response/CheckConsistencyResponse.java
+++ b/jota/src/main/java/jota/dto/response/CheckConsistencyResponse.java
@@ -1,0 +1,27 @@
+package jota.dto.response;
+
+/**
+ * Response of {@link jota.dto.request.IotaCheckConsistencyRequest}.
+ **/
+public class CheckConsistencyResponse extends AbstractResponse {
+
+    private boolean state;
+    private String info;
+
+    /**
+     * Gets the state.
+     *
+     * @return The state.
+     */
+    public boolean getState() {
+        return state;
+    }
+
+    /**
+     * If state is false, this provides information on the cause of the inconsistency.
+     * @return
+     */
+    public String getInfo() {
+        return info;
+    }
+}

--- a/jota/src/main/java/jota/error/ArgumentException.java
+++ b/jota/src/main/java/jota/error/ArgumentException.java
@@ -6,7 +6,6 @@ package jota.error;
  * @author Adrian
  */
 public class ArgumentException extends BaseException {
-
     /**
      * Serial version UID
      */

--- a/jota/src/main/java/jota/error/NotPromotableException.java
+++ b/jota/src/main/java/jota/error/NotPromotableException.java
@@ -1,0 +1,10 @@
+package jota.error;
+
+/**
+ * This exception occurs as part of a `promoteTransaction` call if the transaction is not promotable.
+ */
+public class NotPromotableException extends BaseException{
+    public NotPromotableException(String info) {
+        super("Transaction is not promotable: " + info);
+    }
+}

--- a/jota/src/test/java/jota/IotaAPITest.java
+++ b/jota/src/test/java/jota/IotaAPITest.java
@@ -78,7 +78,7 @@ public class IotaAPITest {
     public void shouldCreateIotaApiProxyInstanceWithDefaultValues() {
         iotaAPI = new IotaAPI.Builder().build();
         assertThat(iotaAPI, IsNull.notNullValue());
-        assertThat(iotaAPI.getHost(), Is.is("node.iotawallet.info"));
+        assertThat(iotaAPI.getHost(), Is.is("node.testnet.iota.org"));
         assertThat(iotaAPI.getPort(), Is.is("14265"));
         assertThat(iotaAPI.getProtocol(), Is.is("http"));
     }
@@ -219,6 +219,15 @@ public class IotaAPITest {
         GetBundleResponse gbr = iotaAPI.getBundle(TEST_HASH);
         System.out.println(gbr);
         assertThat(gbr, IsNull.notNullValue());
+    }
+
+    @Test
+    @Category(IntegrationTest.class)
+    public void shouldCheckConsistency() throws ArgumentException {
+        GetNodeInfoResponse gni = iotaAPI.getNodeInfo();
+        CheckConsistencyResponse ccr = iotaAPI.checkConsistency(gni.getLatestSolidSubtangleMilestone());
+        System.out.println(ccr);
+        assertThat(ccr, IsNull.notNullValue());
     }
 
     @Test

--- a/node_config.properties
+++ b/node_config.properties
@@ -1,4 +1,4 @@
 iota.node.protocol=http
-iota.node.host=node.iotawallet.info
-iota.node.port=14265
+iota.node.host=nodes.testnet.iota.org
+iota.node.port=80
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
     </developers>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- plugins -->


### PR DESCRIPTION
Example usage:
```
 Bundle b = new Bundle();
        b.addEntry(1, "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", 0, "999999999999999999999999999", System.currentTimeMillis() / 1000);

        List<String> signatureParts = new ArrayList<>();
        signatureParts.add(StringUtils.repeat('9', 27*81));
        b.addTrytes(signatureParts);
        b.finalize(SpongeFactory.create(SpongeFactory.Mode.KERL));

        List<Transaction> res = iotaAPI.promoteTransaction(ni.getLatestMilestone(), 3, 9, b);
        System.err.println(res);
```

Fixes #107 