### PR TITLE
Add `checkConsistency` and `promoteTransaction` API endpoints

### DIFF
--- a/jota/src/main/java/jota/IotaAPI.java
+++ b/jota/src/main/java/jota/IotaAPI.java
@@ -647,6 +647,8 @@ public class IotaAPI extends IotaAPICore {
 
         long totalSum = 0;
         String bundleHash = bundle.getTransactions().get(0).getBundle();
+        System.out.println(bundle.getTransactions().get(0));
+        
 
         ICurl curl = SpongeFactory.create(SpongeFactory.Mode.KERL);
         curl.reset();
@@ -694,8 +696,12 @@ public class IotaAPI extends IotaAPICore {
         String bundleFromTxString = Converter.trytes(bundleFromTrxs);
 
         // Check if bundle hash is the same as returned by tx object
-        if (!bundleFromTxString.equals(bundleHash))
+        if (!bundleFromTxString.equals(bundleHash)) {
+            System.out.println(bundleHash);
+            System.out.println(bundleFromTxString);
             throw new ArgumentException(INVALID_BUNDLE_HASH_ERROR);
+        }
+        
         // Last tx in the bundle should have currentIndex === lastIndex
         bundle.setLength(bundle.getTransactions().size());
         if (!(bundle.getTransactions().get(bundle.getLength() - 1).getCurrentIndex() == (bundle.getTransactions().get(bundle.getLength() - 1).getLastIndex())))
@@ -850,7 +856,7 @@ public class IotaAPI extends IotaAPICore {
      */
     public Bundle traverseBundle(String trunkTx, String bundleHash, Bundle bundle) throws ArgumentException {
         GetTrytesResponse gtr = getTrytes(trunkTx);
-
+        
         if (gtr != null) {
 
             if (gtr.getTrytes().length == 0) {

--- a/jota/src/main/java/jota/IotaAPICommands.java
+++ b/jota/src/main/java/jota/IotaAPICommands.java
@@ -19,7 +19,8 @@ public enum IotaAPICommands {
     ATTACH_TO_TANGLE("attachToTangle"),
     INTERRUPT_ATTACHING_TO_TANGLE("interruptAttachingToTangle"),
     BROADCAST_TRANSACTIONS("broadcastTransactions"),
-    STORE_TRANSACTIONS("storeTransactions");
+    STORE_TRANSACTIONS("storeTransactions"),
+    CHECK_CONSISTENCY("checkConsistency");
 
     private String command;
 

--- a/jota/src/main/java/jota/IotaAPICore.java
+++ b/jota/src/main/java/jota/IotaAPICore.java
@@ -293,14 +293,22 @@ public class IotaAPICore {
     }
 
     /**
-     * Tip selection which returns trunkTransaction and branchTransaction. The input value is the latest coordinator milestone, as provided through the getNodeInfo API call.
+     * Tip selection which returns trunkTransaction and branchTransaction.
      *
      * @param depth The number of bundles to go back to determine the transactions for approval.
+     * @param reference The reference transaction to start the random walk from.
      * @return The Tip selection which returns trunkTransaction and branchTransaction
      */
-    public GetTransactionsToApproveResponse getTransactionsToApprove(Integer depth) {
-        final Call<GetTransactionsToApproveResponse> res = service.getTransactionsToApprove(IotaGetTransactionsToApproveRequest.createIotaGetTransactionsToApproveRequest(depth));
+    public GetTransactionsToApproveResponse getTransactionsToApprove(Integer depth, String reference) {
+        final Call<GetTransactionsToApproveResponse> res = service.getTransactionsToApprove(IotaGetTransactionsToApproveRequest.createIotaGetTransactionsToApproveRequest(depth, reference));
         return wrapCheckedException(res).body();
+    }
+
+    /**
+     * {@link #getTransactionsToApprove(Integer, String)}
+     */
+    public GetTransactionsToApproveResponse getTransactionsToApprove(Integer depth) {
+        return getTransactionsToApprove(depth, null);
     }
 
     /**
@@ -332,6 +340,22 @@ public class IotaAPICore {
         }
         return getBalances(threshold, addressesWithoutChecksum.toArray(new String[]{}));
     }
+
+    /**
+     * Checks the consistency of the subtangle formed by the provided tails.
+     *
+     * @param tails The tails describing the subtangle.
+     * @return The The the raw transaction data (trytes) of a specific transaction.
+     */
+    public CheckConsistencyResponse checkConsistency(String... tails) throws ArgumentException {
+        if (!InputValidator.isArrayOfHashes(tails)) {
+            throw new ArgumentException(INVALID_HASHES_INPUT_ERROR);
+        }
+
+        final Call<CheckConsistencyResponse> res = service.checkConsistency(IotaCheckConsistencyRequest.create(tails));
+        return wrapCheckedException(res).body();
+    }
+
 
     /**
      * Attaches the specified transactions (trytes) to the Tangle by doing Proof of Work.

--- a/jota/src/main/java/jota/IotaAPICore.java
+++ b/jota/src/main/java/jota/IotaAPICore.java
@@ -56,7 +56,7 @@ public class IotaAPICore {
         postConstruct();
     }
 
-    protected static <T> Response<T> wrapCheckedException(final Call<T> call) {
+    protected static <T> Response<T> wrapCheckedException(final Call<T> call) throws ArgumentException {
         try {
             final Response<T> res = call.execute();
 
@@ -67,11 +67,7 @@ public class IotaAPICore {
             }
 
             if (res.code() == 400) {
-                try {
-                    throw new ArgumentException(error);
-                } catch (ArgumentException e) {
-                    e.printStackTrace();
-                }
+                throw new ArgumentException(error);
 
             } else if (res.code() == 401) {
                 throw new IllegalAccessError("401 " + error);
@@ -138,8 +134,9 @@ public class IotaAPICore {
      * Get the node information.
      *
      * @return The information about the node.
+     * @throws ArgumentException 
      */
-    public GetNodeInfoResponse getNodeInfo() {
+    public GetNodeInfoResponse getNodeInfo() throws ArgumentException {
         final Call<GetNodeInfoResponse> res = service.getNodeInfo(IotaCommandRequest.createNodeInfoRequest());
         return wrapCheckedException(res).body();
     }
@@ -148,8 +145,9 @@ public class IotaAPICore {
      * Get the list of neighbors from the node.
      *
      * @return The set of neighbors the node is connected with.
+     * @throws ArgumentException 
      */
-    public GetNeighborsResponse getNeighbors() {
+    public GetNeighborsResponse getNeighbors() throws ArgumentException {
         final Call<GetNeighborsResponse> res = service.getNeighbors(IotaCommandRequest.createGetNeighborsRequest());
         return wrapCheckedException(res).body();
     }
@@ -158,8 +156,9 @@ public class IotaAPICore {
      * Add a list of neighbors to the node.
      *
      * @param uris The list of URI elements.
+     * @throws ArgumentException 
      */
-    public AddNeighborsResponse addNeighbors(String... uris) {
+    public AddNeighborsResponse addNeighbors(String... uris) throws ArgumentException {
         final Call<AddNeighborsResponse> res = service.addNeighbors(IotaNeighborsRequest.createAddNeighborsRequest(uris));
         return wrapCheckedException(res).body();
     }
@@ -168,8 +167,9 @@ public class IotaAPICore {
      * Removes a list of neighbors from the node.
      *
      * @param uris The list of URI elements.
+     * @throws ArgumentException 
      */
-    public RemoveNeighborsResponse removeNeighbors(String... uris) {
+    public RemoveNeighborsResponse removeNeighbors(String... uris) throws ArgumentException {
         final Call<RemoveNeighborsResponse> res = service.removeNeighbors(IotaNeighborsRequest.createRemoveNeighborsRequest(uris));
         return wrapCheckedException(res).body();
     }
@@ -178,8 +178,9 @@ public class IotaAPICore {
      * Get the list of latest tips (unconfirmed transactions).
      *
      * @return The the list of tips.
+     * @throws ArgumentException 
      */
-    public GetTipsResponse getTips() {
+    public GetTipsResponse getTips() throws ArgumentException {
         final Call<GetTipsResponse> res = service.getTips(IotaCommandRequest.createGetTipsRequest());
         return wrapCheckedException(res).body();
     }
@@ -189,8 +190,9 @@ public class IotaAPICore {
      * Find the transactions which match the specified input
      *
      * @return The transaction hashes which are returned depend on the input.
+     * @throws ArgumentException 
      */
-    public FindTransactionResponse findTransactions(String[] addresses, String[] tags, String[] approvees, String[] bundles) {
+    public FindTransactionResponse findTransactions(String[] addresses, String[] tags, String[] approvees, String[] bundles) throws ArgumentException {
 
         final IotaFindTransactionsRequest findTransRequest = IotaFindTransactionsRequest
                 .createFindTransactionRequest()
@@ -225,8 +227,9 @@ public class IotaAPICore {
      *
      * @param bundles A List of bundles.
      * @return The transaction hashes which are returned depend on the input.
+     * @throws ArgumentException 
      */
-    public FindTransactionResponse findTransactionsByBundles(final String... bundles) {
+    public FindTransactionResponse findTransactionsByBundles(final String... bundles) throws ArgumentException {
         return findTransactions(null, null, null, bundles);
     }
 
@@ -235,8 +238,9 @@ public class IotaAPICore {
      *
      * @param approvees A List of approvess.
      * @return The transaction hashes which are returned depend on the input.
+     * @throws ArgumentException 
      */
-    public FindTransactionResponse findTransactionsByApprovees(final String... approvees) {
+    public FindTransactionResponse findTransactionsByApprovees(final String... approvees) throws ArgumentException {
         return findTransactions(null, null, approvees, null);
     }
 
@@ -246,8 +250,9 @@ public class IotaAPICore {
      *
      * @param digests A List of digests.
      * @return The transaction hashes which are returned depend on the input.
+     * @throws ArgumentException 
      */
-    public FindTransactionResponse findTransactionsByDigests(final String... digests) {
+    public FindTransactionResponse findTransactionsByDigests(final String... digests) throws ArgumentException {
         return findTransactions(null, digests, null, null);
     }
 
@@ -287,7 +292,7 @@ public class IotaAPICore {
         if (!InputValidator.isArrayOfHashes(hashes)) {
             throw new ArgumentException(INVALID_HASHES_INPUT_ERROR);
         }
-
+        
         final Call<GetTrytesResponse> res = service.getTrytes(IotaGetTrytesRequest.createGetTrytesRequest(hashes));
         return wrapCheckedException(res).body();
     }
@@ -298,16 +303,18 @@ public class IotaAPICore {
      * @param depth The number of bundles to go back to determine the transactions for approval.
      * @param reference The reference transaction to start the random walk from.
      * @return The Tip selection which returns trunkTransaction and branchTransaction
+     * @throws ArgumentException 
      */
-    public GetTransactionsToApproveResponse getTransactionsToApprove(Integer depth, String reference) {
+    public GetTransactionsToApproveResponse getTransactionsToApprove(Integer depth, String reference) throws ArgumentException {
         final Call<GetTransactionsToApproveResponse> res = service.getTransactionsToApprove(IotaGetTransactionsToApproveRequest.createIotaGetTransactionsToApproveRequest(depth, reference));
         return wrapCheckedException(res).body();
     }
 
     /**
      * {@link #getTransactionsToApprove(Integer, String)}
+     * @throws ArgumentException 
      */
-    public GetTransactionsToApproveResponse getTransactionsToApprove(Integer depth) {
+    public GetTransactionsToApproveResponse getTransactionsToApprove(Integer depth) throws ArgumentException {
         return getTransactionsToApprove(depth, null);
     }
 
@@ -317,8 +324,9 @@ public class IotaAPICore {
      * @param threshold The confirmation threshold, should be set to 100.
      * @param addresses The array list of addresses you want to get the confirmed balance from.
      * @return The confirmed balance which a list of addresses have at the latest confirmed milestone.
+     * @throws ArgumentException 
      */
-    private GetBalancesResponse getBalances(Integer threshold, String[] addresses) {
+    private GetBalancesResponse getBalances(Integer threshold, String[] addresses) throws ArgumentException {
         final Call<GetBalancesResponse> res = service.getBalances(IotaGetBalancesRequest.createIotaGetBalancesRequest(threshold, addresses));
         return wrapCheckedException(res).body();
     }
@@ -403,8 +411,9 @@ public class IotaAPICore {
 
     /**
      * Interrupts and completely aborts the attachToTangle process.
+     * @throws ArgumentException 
      */
-    public InterruptAttachingToTangleResponse interruptAttachingToTangle() {
+    public InterruptAttachingToTangleResponse interruptAttachingToTangle() throws ArgumentException {
         final Call<InterruptAttachingToTangleResponse> res = service.interruptAttachingToTangle(IotaCommandRequest.createInterruptAttachToTangleRequest());
         return wrapCheckedException(res).body();
     }
@@ -428,8 +437,9 @@ public class IotaAPICore {
      * Store transactions into the local storage. The trytes to be used for this call are returned by attachToTangle.
      *
      * @param trytes The list of raw data of transactions to be rebroadcast.
+     * @throws ArgumentException 
      */
-    public StoreTransactionsResponse storeTransactions(String... trytes) {
+    public StoreTransactionsResponse storeTransactions(String... trytes) throws ArgumentException {
         final Call<StoreTransactionsResponse> res = service.storeTransactions(IotaStoreTransactionsRequest.createStoreTransactionsRequest(trytes));
         return wrapCheckedException(res).body();
     }

--- a/jota/src/main/java/jota/IotaAPIService.java
+++ b/jota/src/main/java/jota/IotaAPIService.java
@@ -159,4 +159,14 @@ public interface IotaAPIService {
     @Headers({CONTENT_TYPE_HEADER, USER_AGENT_HEADER})
     @POST("./")
     Call<StoreTransactionsResponse> storeTransactions(@Body IotaStoreTransactionsRequest request);
+
+    /**
+     * Checks the consistency of the subtangle descirbed by the provided tails.
+     * <p>
+     * {@code curl http://localhost:14265 -X POST -H 'X-IOTA-API-Version: 1.4.1' -H 'Content-Type: application/json'}
+     * {@code -d '{"command": "checkConsistency", "tails": ["AYHLOYXFXYNBX9L9TLS9LGKPGJCTHVPEVYNMZEEIPVBVLSIBZEJRKXYYOW9NXKTNQSVFBMGUKVYOZ9999"]}'}
+     */
+    @Headers({CONTENT_TYPE_HEADER, USER_AGENT_HEADER})
+    @POST("./")
+    Call<CheckConsistencyResponse> checkConsistency(@Body IotaCheckConsistencyRequest request);
 }

--- a/jota/src/main/java/jota/dto/request/IotaCheckConsistencyRequest.java
+++ b/jota/src/main/java/jota/dto/request/IotaCheckConsistencyRequest.java
@@ -1,0 +1,45 @@
+package jota.dto.request;
+
+import jota.IotaAPICommands;
+
+/**
+ * This class represents the core api request 'checkConsistency'.
+ **/
+public class IotaCheckConsistencyRequest extends IotaCommandRequest {
+
+    private String[] tails;
+
+    /**
+     * Initializes a new instance of the IotaCheckConsistencyRequest class.
+     */
+    private IotaCheckConsistencyRequest(final String... tails) {
+        super(IotaAPICommands.CHECK_CONSISTENCY);
+        this.tails = tails;
+    }
+
+    /**
+     * Create a new instance of the IotaGetBalancesRequest class.
+     */
+    public static IotaCheckConsistencyRequest create(final String... tails) {
+        return new IotaCheckConsistencyRequest(tails);
+    }
+
+    /**
+     * Gets the tails.
+     *
+     * @return The tails.
+     */
+    public String[] getTails() {
+        return tails;
+    }
+
+    /**
+     * Sets the tails.
+     *
+     * @param tails The tails.
+     */
+    public void setTails(String[] tails) {
+        this.tails = tails;
+    }
+}
+

--- a/jota/src/main/java/jota/dto/request/IotaGetTransactionsToApproveRequest.java
+++ b/jota/src/main/java/jota/dto/request/IotaGetTransactionsToApproveRequest.java
@@ -7,38 +7,59 @@ import jota.IotaAPICommands;
  **/
 public class IotaGetTransactionsToApproveRequest extends IotaCommandRequest {
 
-    private Integer depth;
+  private Integer depth;
+  private String reference;
 
-    /**
-     * Initializes a new instance of the IotaGetTransactionsToApproveRequest class.
-     */
-    private IotaGetTransactionsToApproveRequest(final Integer depth) {
-        super(IotaAPICommands.GET_TRANSACTIONS_TO_APPROVE);
-        this.depth = depth;
-    }
+  /**
+   * Initializes a new instance of the IotaGetTransactionsToApproveRequest class.
+   */
+  private IotaGetTransactionsToApproveRequest(final Integer depth, final String reference) {
+    super(IotaAPICommands.GET_TRANSACTIONS_TO_APPROVE);
+    this.depth = depth;
+    this.reference = reference;
+  }
 
-    /**
-     * Create a new instance of the IotaGetTransactionsToApproveRequest class.
-     */
-    public static IotaGetTransactionsToApproveRequest createIotaGetTransactionsToApproveRequest(Integer depth) {
-        return new IotaGetTransactionsToApproveRequest(depth);
-    }
+  /**
+   * Create a new instance of the IotaGetTransactionsToApproveRequest class.
+   */
+  public static IotaGetTransactionsToApproveRequest createIotaGetTransactionsToApproveRequest(Integer depth, String reference) {
+    return new IotaGetTransactionsToApproveRequest(depth, reference);
+  }
 
-    /**
-     * Gets the depth.
-     *
-     * @return The depth.
-     */
-    public Integer getDepth() {
-        return depth;
-    }
+  /**
+   * Gets the depth.
+   *
+   * @return The depth.
+   */
+  public Integer getDepth() {
+    return depth;
+  }
 
-    /**
-     * Sets the depth.
-     *
-     * @param depth The depth.
-     */
-    public void setDepth(Integer depth) {
-        this.depth = depth;
-    }
+  /**
+   * /**
+   * Sets the depth.
+   *
+   * @param depth The depth.
+   */
+  public void setDepth(Integer depth) {
+    this.depth = depth;
+  }
+
+  /**
+   * Gets the reference to use
+   *
+   * @return The reference point.
+   */
+  public String getReference() {
+    return reference;
+  }
+
+  /**
+   * Sets the reference.
+   *
+   * @param reference The reference
+   */
+  public void setReference(String reference) {
+    this.reference = reference;
+  }
 }

--- a/jota/src/main/java/jota/dto/response/CheckConsistencyResponse.java
+++ b/jota/src/main/java/jota/dto/response/CheckConsistencyResponse.java
@@ -1,0 +1,27 @@
+package jota.dto.response;
+
+/**
+ * Response of {@link jota.dto.request.IotaCheckConsistencyRequest}.
+ **/
+public class CheckConsistencyResponse extends AbstractResponse {
+
+    private boolean state;
+    private String info;
+
+    /**
+     * Gets the state.
+     *
+     * @return The state.
+     */
+    public boolean getState() {
+        return state;
+    }
+
+    /**
+     * If state is false, this provides information on the cause of the inconsistency.
+     * @return
+     */
+    public String getInfo() {
+        return info;
+    }
+}

--- a/jota/src/main/java/jota/error/ArgumentException.java
+++ b/jota/src/main/java/jota/error/ArgumentException.java
@@ -6,7 +6,6 @@ package jota.error;
  * @author Adrian
  */
 public class ArgumentException extends BaseException {
-
     /**
      * Serial version UID
      */

--- a/jota/src/main/java/jota/error/NotPromotableException.java
+++ b/jota/src/main/java/jota/error/NotPromotableException.java
@@ -1,0 +1,10 @@
+package jota.error;
+
+/**
+ * This exception occurs as part of a `promoteTransaction` call if the transaction is not promotable.
+ */
+public class NotPromotableException extends BaseException{
+    public NotPromotableException(String info) {
+        super("Transaction is not promotable: " + info);
+    }
+}

--- a/jota/src/test/java/jota/AbstractMockServer.java
+++ b/jota/src/test/java/jota/AbstractMockServer.java
@@ -9,9 +9,13 @@ import java.io.IOException;
 import static java.nio.charset.Charset.defaultCharset;
 import static net.jadler.Jadler.*;
 
-abstract class AbstractMockServer {
+public abstract class AbstractMockServer {
 
     IotaAPI iotaAPI;
+    
+    public AbstractMockServer() {
+        
+    }
 
     @Before
     public void setUp() {
@@ -35,17 +39,17 @@ abstract class AbstractMockServer {
         private String requestFileName;
         private String responseFileName;
 
-        ApiMock command(IotaAPICommands command) {
+        public ApiMock command(IotaAPICommands command) {
             this.command = command;
             return this;
         }
 
-        ApiMock request(String requestFileName) {
+        public ApiMock request(String requestFileName) {
             this.requestFileName = requestFileName;
             return this;
         }
 
-        ApiMock response(String responseFileName) {
+        public ApiMock response(String responseFileName) {
             this.responseFileName = responseFileName;
             return this;
         }

--- a/jota/src/test/java/jota/IotaAPITest.java
+++ b/jota/src/test/java/jota/IotaAPITest.java
@@ -78,7 +78,7 @@ public class IotaAPITest {
     public void shouldCreateIotaApiProxyInstanceWithDefaultValues() {
         iotaAPI = new IotaAPI.Builder().build();
         assertThat(iotaAPI, IsNull.notNullValue());
-        assertThat(iotaAPI.getHost(), Is.is("node.iotawallet.info"));
+        assertThat(iotaAPI.getHost(), Is.is("node.testnet.iota.org"));
         assertThat(iotaAPI.getPort(), Is.is("14265"));
         assertThat(iotaAPI.getProtocol(), Is.is("http"));
     }
@@ -219,6 +219,15 @@ public class IotaAPITest {
         GetBundleResponse gbr = iotaAPI.getBundle(TEST_HASH);
         System.out.println(gbr);
         assertThat(gbr, IsNull.notNullValue());
+    }
+
+    @Test
+    @Category(IntegrationTest.class)
+    public void shouldCheckConsistency() throws ArgumentException {
+        GetNodeInfoResponse gni = iotaAPI.getNodeInfo();
+        CheckConsistencyResponse ccr = iotaAPI.checkConsistency(gni.getLatestSolidSubtangleMilestone());
+        System.out.println(ccr);
+        assertThat(ccr, IsNull.notNullValue());
     }
 
     @Test

--- a/jota/src/test/java/jota/IotaAPITest.java
+++ b/jota/src/test/java/jota/IotaAPITest.java
@@ -8,6 +8,8 @@ import jota.model.Bundle;
 import jota.model.Input;
 import jota.model.Transaction;
 import jota.model.Transfer;
+import jota.utils.IotaAPIUtils;
+
 import org.hamcrest.core.Is;
 import org.hamcrest.core.IsNull;
 import org.junit.Assert;
@@ -22,6 +24,7 @@ import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Let's do some integration test coverage against a default local real node.
@@ -78,7 +81,7 @@ public class IotaAPITest {
     public void shouldCreateIotaApiProxyInstanceWithDefaultValues() {
         iotaAPI = new IotaAPI.Builder().build();
         assertThat(iotaAPI, IsNull.notNullValue());
-        assertThat(iotaAPI.getHost(), Is.is("node.testnet.iota.org"));
+        assertThat(iotaAPI.getHost(), Is.is("nodes.testnet.iota.org"));
         assertThat(iotaAPI.getPort(), Is.is("14265"));
         assertThat(iotaAPI.getProtocol(), Is.is("http"));
     }
@@ -209,13 +212,15 @@ public class IotaAPITest {
 
     @Test(expected = ArgumentException.class)
     public void shouldNotGetBundle() throws ArgumentException {
-        GetBundleResponse gbr = iotaAPI.getBundle("SADASD");
-        assertThat(gbr, IsNull.notNullValue());
+        iotaAPI.getBundle("SADASD");
     }
 
     @Test
     @Category(IntegrationTest.class)
     public void shouldGetBundle() throws ArgumentException {
+        GetTrytesResponse ret = iotaAPI.getTrytes(TEST_HASH);
+        System.out.println(new Transaction(ret.getTrytes()[0]));
+        
         GetBundleResponse gbr = iotaAPI.getBundle(TEST_HASH);
         System.out.println(gbr);
         assertThat(gbr, IsNull.notNullValue());
@@ -266,7 +271,18 @@ public class IotaAPITest {
     @Test()
     @Category(IntegrationTest.class)
     public void shouldBroadcastAndStore() throws ArgumentException {
-        System.out.println(iotaAPI.broadcastAndStore(TEST_TRYTES));
+        //Manually generate a transaction?
+    }
+    
+    @Test()
+    @Category(IntegrationTest.class)
+    public void shouldFailBeforeSnapshotTimeStamp() throws ArgumentException {
+        try {
+            iotaAPI.broadcastAndStore(TEST_TRYTES);
+            fail("Transaction did not fail on old timestamp value");
+        } catch (IllegalAccessError e) {
+            //TODO Check for specific error
+        }
     }
 
     @Ignore

--- a/jota/src/test/java/jota/IotaCoreApiTest.java
+++ b/jota/src/test/java/jota/IotaCoreApiTest.java
@@ -9,9 +9,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.util.Arrays;
 import java.util.Collections;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
 
 /**
  * @author Adrian
@@ -30,7 +34,7 @@ public class IotaCoreApiTest {
 
     @Test
     @Category(IntegrationTest.class)
-    public void shouldGetNodeInfo() {
+    public void shouldGetNodeInfo() throws ArgumentException {
         GetNodeInfoResponse nodeInfo = proxy.getNodeInfo();
         System.out.println(new Gson().toJson(nodeInfo));
         assertThat(nodeInfo.getAppVersion(), IsNull.notNullValue());
@@ -53,28 +57,28 @@ public class IotaCoreApiTest {
 
     @Test
     @Category(IntegrationTest.class)
-    public void shouldGetNeighbors() {
+    public void shouldGetNeighbors() throws ArgumentException {
         GetNeighborsResponse neighbors = proxy.getNeighbors();
         assertThat(neighbors.getNeighbors(), IsNull.notNullValue());
     }
 
     @Test(expected = IllegalAccessError.class)
     @Category(IntegrationTest.class)
-    public void shouldAddNeighbors() {
+    public void shouldAddNeighbors() throws ArgumentException {
         AddNeighborsResponse res = proxy.addNeighbors("udp://8.8.8.8:14265");
         assertThat(res, IsNull.notNullValue());
     }
 
     @Test(expected = IllegalAccessError.class)
     @Category(IntegrationTest.class)
-    public void shouldRemoveNeighbors() {
+    public void shouldRemoveNeighbors() throws ArgumentException {
         RemoveNeighborsResponse res = proxy.removeNeighbors("udp://8.8.8.8:14265");
         assertThat(res, IsNull.notNullValue());
     }
 
     @Test
     @Category(IntegrationTest.class)
-    public void shouldGetTips() {
+    public void shouldGetTips() throws ArgumentException {
         GetTipsResponse tips = proxy.getTips();
         assertThat(tips, IsNull.notNullValue());
     }
@@ -88,21 +92,21 @@ public class IotaCoreApiTest {
 
     @Test
     @Category(IntegrationTest.class)
-    public void shouldFindTransactionsByApprovees() {
+    public void shouldFindTransactionsByApprovees() throws ArgumentException {
         FindTransactionResponse trans = proxy.findTransactionsByApprovees(TEST_HASH);
         assertThat(trans.getHashes(), IsNull.notNullValue());
     }
 
     @Test
     @Category(IntegrationTest.class)
-    public void shouldFindTransactionsByBundles() {
+    public void shouldFindTransactionsByBundles() throws ArgumentException {
         FindTransactionResponse trans = proxy.findTransactionsByBundles(TEST_HASH);
         assertThat(trans.getHashes(), IsNull.notNullValue());
     }
 
     @Test
     @Category(IntegrationTest.class)
-    public void shouldFindTransactionsByDigests() {
+    public void shouldFindTransactionsByDigests() throws ArgumentException {
         FindTransactionResponse trans = proxy.findTransactionsByDigests(TEST_HASH);
         assertThat(trans.getHashes(), IsNull.notNullValue());
     }
@@ -116,8 +120,15 @@ public class IotaCoreApiTest {
 
     @Test
     @Category(IntegrationTest.class)
-    public void shouldNotGetInclusionStates() throws ArgumentException {
-        proxy.getInclusionStates(new String[]{TEST_HASH}, new String[]{"ZIJGAJ9AADLRPWNCYNNHUHRRAC9QOUDATEDQUMTNOTABUVRPTSTFQDGZKFYUUIE9ZEBIVCCXXXLKX9999"});
+    public void shouldNotGetInclusionStates(){
+        try {
+            proxy.getInclusionStates(new String[]{TEST_HASH}, new String[]{"ZIJGAJ9AADLRPWNCYNNHUHRRAC9QOUDATEDQUMTNOTABUVRPTSTFQDGZKFYUUIE9ZEBIVCCXXXLKX9999"});
+            fail("failed to throw error on wrong bundle hash");
+        } catch (ArgumentException e) {
+          //TODO verify correct error
+            //Successs
+        }
+
     }
 
     @Test
@@ -129,15 +140,27 @@ public class IotaCoreApiTest {
 
     @Test // very long execution
     @Category(IntegrationTest.class)
-    public void shouldGetTransactionsToApprove() {
-        GetTransactionsToApproveResponse res = proxy.getTransactionsToApprove(27);
+    public void shouldGetTransactionsToApprove() throws ArgumentException {
+        GetTransactionsToApproveResponse res = proxy.getTransactionsToApprove(15);
         assertThat(res.getTrunkTransaction(), IsNull.notNullValue());
         assertThat(res.getBranchTransaction(), IsNull.notNullValue());
+    }
+    
+    @Test // very long execution
+    @Category(IntegrationTest.class)
+    public void shouldInvalidDepth() throws ArgumentException {
+        try {
+            GetTransactionsToApproveResponse res = proxy.getTransactionsToApprove(27);
+            fail("Depth more then 15 is not supported by default");
+        } catch (ArgumentException e) {
+            //TODO verify correct error
+            //Good!
+        }
     }
 
     @Test
     @Category(IntegrationTest.class)
-    public void shouldFindTransactions() {
+    public void shouldFindTransactions() throws ArgumentException {
         String test = TEST_BUNDLE;
         FindTransactionResponse resp = proxy.findTransactions(new String[]{test}, new String[]{test}, new String[]{test}, new String[]{test});
         System.out.println(new Gson().toJson(resp));
@@ -147,6 +170,8 @@ public class IotaCoreApiTest {
     @Category(IntegrationTest.class)
     public void shouldGetBalances() throws ArgumentException {
         GetBalancesResponse res = proxy.getBalances(100, Collections.singletonList(TEST_ADDRESS_WITH_CHECKSUM));
+        System.out.println(res.getDuration());
+        
         assertThat(res.getBalances(), IsNull.notNullValue());
         assertThat(res.getMilestone(), IsNull.notNullValue());
         assertThat(res.getMilestoneIndex(), IsNull.notNullValue());

--- a/node_config.properties
+++ b/node_config.properties
@@ -1,4 +1,4 @@
 iota.node.protocol=http
-iota.node.host=node.iotawallet.info
-iota.node.port=14265
+iota.node.host=nodes.testnet.iota.org
+iota.node.port=80
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
     </developers>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- plugins -->


### PR DESCRIPTION
Same as #108, but fixed the test

Example usage:
```
 Bundle b = new Bundle();
        b.addEntry(1, "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", 0, "999999999999999999999999999", System.currentTimeMillis() / 1000);

        List<String> signatureParts = new ArrayList<>();
        signatureParts.add(StringUtils.repeat('9', 27*81));
        b.addTrytes(signatureParts);
        b.finalize(SpongeFactory.create(SpongeFactory.Mode.KERL));

        List<Transaction> res = iotaAPI.promoteTransaction(ni.getLatestMilestone(), 3, 9, b);
        System.err.println(res);
```

Fixes #107 