### PR TITLE
Send transfer inconsistency

### DIFF
--- a/jota/src/main/java/jota/IotaAPICore.java
+++ b/jota/src/main/java/jota/IotaAPICore.java
@@ -418,6 +418,7 @@ public class IotaAPICore {
         }
 
         if (localPoW != null) {
+            System.out.println("Doing local PoW!");
             final String[] resultTrytes = new String[trytes.length];
             String previousTransaction = null;
             for (int i = 0; i < trytes.length; i++) {


### PR DESCRIPTION
When sending a 0 value transaction using sendTransfer, the transaction order is not reversed.
This causes a an inconsistent consistency error on the tangle. 

Example: https://thetangle.org/transaction/9BMGUBALY9QINKBHRXRAYYFJNACKKHWCXIKMWEKFJA9V9YPWDDSWSJFLAIGFIALSTOSVVMJBKUHP99999

Fixed #87 