### PR TITLE
Make integration tests executable

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,7 @@
+# Development
+
+## Testing
+
+The project has special integration tests, which can be recognized by the tag `IntegrationTest`. These connect against a live node. To execute these tests the profile `allTests` must be active.
+
+`mvn clean test -PallTests`

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <excludedTests>IntegrationTest</excludedTests>
 
         <!-- plugins -->
         <version.maven-checkstyle-plugin>3.0.0</version.maven-checkstyle-plugin>
@@ -285,7 +286,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${version.maven-surefire-plugin}</version>
                 <configuration>
-                    <excludedGroups>IntegrationTest</excludedGroups>
+                    <excludedGroups>${excludedTests}</excludedGroups>
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
@@ -312,6 +313,12 @@
     </reporting>
 
     <profiles>
+        <profile>
+            <id>allTests</id>
+            <properties>
+                <excludedTests></excludedTests>
+            </properties>
+        </profile>
         <profile>
             <id>build</id>
             <activation>
@@ -377,7 +384,6 @@
                 </plugins>
             </build>
         </profile>
-
         <profile>
             <id>release</id>
             <activation>


### PR DESCRIPTION
# Description of change

Integration tests were not executable via maven. I have added a profile that allows this.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Run `mvn clean test -PallTests`

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests using ginkgo that prove my fix is effective or that my feature works -> not needed
- [ ] New and existing unit tests pass locally with my changes -> not needed
